### PR TITLE
Attempt Fix Encoding Problem for print() on Windows with English System Language

### DIFF
--- a/BlackboardCrawler.py
+++ b/BlackboardCrawler.py
@@ -101,15 +101,15 @@ class BlackboardCrawler:
   def updatePrefs(self, key, value):
     self.prefs[key]=value
 
-  def log(self, s, t=0, coding=stdout.encoding):
+  def log(self, s, t=0, coding='utf-8'):
     if(self.flags.VERBOSE or t!=0):
       curframe = inspect.currentframe()
       calframe = inspect.getouterframes(curframe, 2)
       caller = calframe[1][3]
       if(isinstance(s,unicode)):
-        print(u'{0}:{1}'.format(caller.decode(coding), s))
+        print('{0}:{1}'.format(caller, s.encode(coding)))
       else:
-        print(u'{0}:{1}'.format(caller.decode(coding), s.decode(stdout.encoding)))
+        print('{0}:{1}'.format(caller, s))
 
   def title_print(self, s):
     s = '@ {0} @'.format(s)
@@ -228,7 +228,7 @@ class BlackboardCrawler:
     if(isinstance(path,unicode)):
       self.log(u'path: {0}'.format(path))
     else:
-      self.log(u'path: {0}'.format(path.decode(stdout.encoding)))
+      self.log('path: {0}'.format(path))
     self.log('url: {0}'.format(url))
     self.log("header: {0}".format(resp.headers))
     header_content = headers['Content-Disposition']
@@ -277,7 +277,7 @@ class BlackboardCrawler:
       if(isinstance(file_name,unicode)):
         self.log(u'url: {0} {1}'.format(file_url, file_name))
       else:
-        self.log(u'url: {0} {1}'.format(file_url, file_name.decode(stdout.encoding)))
+        self.log('url: {0} {1}'.format(file_url, file_name))
       self._download_file(file_url, path_prefix)
 
   def _download_item_from_directories(self, path_prefix, directories, depth):
@@ -285,7 +285,7 @@ class BlackboardCrawler:
       return
     for directory in directories:
       directory_url, directory_title = directory
-      self.log('reading: {0} {1}'.format(directory_url, directory_title))
+      self.log(u'reading: {0} {1}'.format(directory_url, directory_title))
       new_prefix = os.path.join(path_prefix, directory_title)
       next_directories, files = self._get_item_from_section(new_prefix, directory)
       self._download_files(new_prefix, files)
@@ -296,7 +296,7 @@ class BlackboardCrawler:
     if(isinstance(section_name,unicode)):
       self.log(u'----reading sections: {0}'.format(section_name))
     else:
-      self.log(u'----reading sections: {0}'.format(section_name.decode(stdout.encoding)))
+      self.log('----reading sections: {0}'.format(section_name))
     dir_name = mkdir(path_prefix)
     # path_prefix = dir_name
     if(self.prefs.blackboard_url not in section_url):
@@ -324,7 +324,7 @@ class BlackboardCrawler:
     if(isinstance(course_name,unicode)):
       self.log(u'reading course: {0}'.format(course_name))
     else:
-      self.log(u'reading course: {0}'.format(course_name.decode(stdout.encoding)))
+      self.log('reading course: {0}'.format(course_name))
     course_url = "{1}/webapps/blackboard/execute/courseMain?course_id={0}".format(course_id, self.prefs.blackboard_url)
     course_url_resp = self.sess.get(course_url)
     section_raw = re.findall('<hr>(.+?)<hr>',course_url_resp.text)[0]

--- a/main.py
+++ b/main.py
@@ -3,7 +3,6 @@
 from Tkinter import *
 import BlackboardCrawler
 import inspect
-from sys import stdout
 
 class Application(Frame):
   debug=False
@@ -149,7 +148,7 @@ class Application(Frame):
       if(isinstance(self.courses[i][2],unicode)):
         self.bc.log(u'rendering {0}'.format(self.courses[i][2]))
       else:
-        self.bc.log(u'rendering {0}'.format(self.courses[i][2].decode(stdout.encoding)))
+        self.bc.log('rendering {0}'.format(self.courses[i][2]))
       course = self.courses[i]
       (course_id, course_code, display_name) = course
       bool_var = BooleanVar()
@@ -181,16 +180,16 @@ class Application(Frame):
     # self._prompt(title="Error", text="login unsuccessful")
     self.bc.log('finish login_unsuccess')
 
-  def log(self, s, t=0, coding=stdout.encoding):
+  def log(self, s, t=0, coding='utf-8'):
     VERBOSE = True if getattr(self,'bc') is None else self.bc.flags.VERBOSE
     if(VERBOSE or t!=0):
       curframe = inspect.currentframe()
       calframe = inspect.getouterframes(curframe, 2)
       caller = calframe[1][3]
       if(isinstance(s,unicode)):
-        print(u'{0}:{1}'.format(caller.decode(coding), s))
+        print('{0}:{1}'.format(caller, s.encode(coding)))
       else:
-        print('{0}:{1}'.format(caller.decode(coding), s.decode(stdout.encoding)))
+        print('{0}:{1}'.format(caller, s))
 
   def _prompt(self, geometry='200x100', title='Prompt', text='content'):
     self.prompt = Toplevel(self)


### PR DESCRIPTION
Test Environment:
OS: Windows 10 Pro Build 1803 (System Language: English) and Ubuntu 18.04.1 LTS
Python Version: 2.7

Since the original website is encoded using `utf-8`, course information such as name is decoded using `utf-8`, and then stored as an Unicode String in python. When the Unicode String is passed as an argument to function print(), the Windows's CMD will try to use its default coding (in this case, `stdout.encoding = 'cp437'`, while Ubuntu's terminal will encode them using `utf-8` and things are working without problem) to encode the Unicode String which is originally decoded using `utf-8`. The following image shows the general error output on Windows's CMD.
![error1](https://user-images.githubusercontent.com/35261006/48721624-40518c80-ec5d-11e8-97fc-3669fcefa488.jpg) 

The attempt fix is proposed where Unicode Strings are manually encoded using `utf-8` before passing to print(). As only Byte Strings are passed, the CMD won't try to encode them using `cp437`. The following image shows the sample output after this attempt fix. (The attempt fix is also verified on Ubuntu)
![fix1](https://user-images.githubusercontent.com/35261006/48723256-18642800-ec61-11e8-82a5-b93d17c7f77e.jpg)

Some arguments passed into function *.log() are revised due to redundancy.