### PR TITLE
Fix Path Format on Windows and Unix System

### DIFF
--- a/utils.py
+++ b/utils.py
@@ -2,10 +2,13 @@ import os
 import uuid
 import string
 
+def directory_flatten(path):
+  for c in '\\/:*?"<>|':
+      path = path.replace(c, '-')
+  return path
+
 def mkdir(name):
-  invalid_chars = ':*?"<>|'
   try:
-    name = ''.join(c for c in name if c not in invalid_chars)
     if(os.path.exists(name)):
       pass # dir exists
     else:
@@ -18,9 +21,7 @@ def mkdir(name):
     return dir_name
 
 def download_file(url, path, sess):
-  invalid_chars = ':*?"<>|'
   try:
-    path = ''.join(c for c in path if c not in invalid_chars)
     if(blackboard_url not in url):
       url = blackboard_url+url
     resp = sess.get(url, stream=True)


### PR DESCRIPTION
Though the new path formatting algorithm has been proposed in #4 in order to deal with Chinese characters, invalid path may be probably generated in the latest version. As directory separator (`\\` on Windows, `/` on Unix System like Ubuntu) is considered as a valid character, existing directory separator within the folder name will be removed or replaced thus the final path is incorrect or even invalid depends on operating system.

For example, given main directory `blackboard` has children `Course_Code`, who also has children `Lecture(1) 14/09/2018`, target download directory after os.path.join() will generated as followings,

`Win: '\\blackboard\\Course_Code\\Lecture(1) 14/09/2018'`
`Unix: '/blackboard/Course_Code/Lecture(1) 14/09/2018'`

In this case, paths will sometimes be incorrect or invalid and the script is stopped. A folder name formatting is proposed to verify each sub-directory before calling os.path.join() to fix this problem.