### PR TITLE
Improve Scraping Strategies

### DIFF
--- a/BlackboardCrawler.py
+++ b/BlackboardCrawler.py
@@ -307,11 +307,12 @@ class BlackboardCrawler:
       section_url = self.prefs.blackboard_url+section_url
     course_section_resp = self.sess.get(section_url)
     directories = re.findall('<a href="(/webapps/blackboard/content/listContent.jsp?.+?)"><span style=".+?">(.+?)</span>', course_section_resp.text)
-    files = re.findall('<a href="(/bbcswebdav.+?)".+?">.+?">(.+)</span>', course_section_resp.text)
+    files = re.findall('<a(?:.+?|)href="(?:https://blackboard.cuhk.edu.hk|)(/bbcswebdav.+?)">(.+?)<', course_section_resp.text)
     """ files type 1
     <a href="/bbcswebdav/pid-2238145-dt-content-rid-8465171_1/xid-8465171_1" onClick="this.href='/webapps/blackboard/execute/content/file?cmd=view&content_id=_2238145_1&course_id=_87673_1'">
       <span style="color:#000000;">lesson 11</span>
     </a>
+    <a href="https://blackboard.cuhk.edu.hk/bbcswebdav/pid-2470832-dt-content-rid-13383234_1/xid-13383234_1">大綱</a>
     """
     files2 = re.findall('<a href="(/bbcswebdav.+?)".+?">.+?">(.+)[^</span>]</a>', course_section_resp.text)
     """ files type 2
@@ -331,8 +332,7 @@ class BlackboardCrawler:
       self.log('reading course: {0}'.format(course_name))
     course_url = "{1}/webapps/blackboard/execute/courseMain?course_id={0}".format(course_id, self.prefs.blackboard_url)
     course_url_resp = self.sess.get(course_url)
-    section_raw = re.findall('<hr>(.+?)<hr>',course_url_resp.text)[0]
-    sections = re.findall('<a href="(/webapps/blackboard/content/listContent.jsp?.+?)".+?">.+?">(.+?)</span>', section_raw)
+    sections = re.findall('<a href="(/webapps/blackboard/content/listContent.jsp?.+?)".+?">.+?">(.+?)</span>', course_url_resp.text)
     return sections
 
   def _init_bb_session(self):


### PR DESCRIPTION
Since the list section_raw is first created by finding section links sandwiched between `<hr>` tags, then list section is created from the list section_raw, the script fails where there is no `<hr>` tag used in the section page (like the capture below) such that both section_raw and section are empty list.
![error1](https://user-images.githubusercontent.com/35261006/50693656-8f6b4980-1072-11e9-83b2-773fa899c304.jpg)
The error message "list index out of range" is caused by calling the value of section[0], where section is in fact a empty list (i.e. section = []).
In line 335, I suggest that a single list section will get the job done.

In addition, I found that some links of file are given by their full URLs instead of root relative URLs (example shown in line 315), the new regex is suggested in 310 to cover those files in scraping.